### PR TITLE
WIP: Implement full-text search in Converse

### DIFF
--- a/migrations/2018-04-14-170750_search-index/down.sql
+++ b/migrations/2018-04-14-170750_search-index/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX idx_fts_search;
+DROP MATERIALIZED VIEW search_index;

--- a/migrations/2018-04-14-170750_search-index/up.sql
+++ b/migrations/2018-04-14-170750_search-index/up.sql
@@ -1,0 +1,21 @@
+-- Prepare a materialised view containing the tsvector data for all
+-- threads and posts. This view is indexed using a GIN-index to enable
+-- performant full-text searches.
+--
+-- For now the query language is hardcoded to be English.
+
+CREATE MATERIALIZED VIEW search_index AS
+  SELECT p.id AS post_id,
+         p.author_name AS author,
+         t.id AS thread_id,
+         t.title AS title,
+         p.body AS body,
+         setweight(to_tsvector('english', t.title), 'A') ||
+         setweight(to_tsvector('english', p.body), 'B') ||
+         setweight(to_tsvector('simple', t.author_name), 'C') ||
+         setweight(to_tsvector('simple', p.author_name), 'C') AS document
+    FROM posts p
+    JOIN threads t
+    ON t.id = p.thread_id;
+
+CREATE INDEX idx_fts_search ON search_index USING gin(document);

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -165,9 +165,9 @@ pub fn reply_thread(state: State<AppState>,
     };
 
     state.db.send(CreatePost(new_post))
+        .flatten()
         .from_err()
-        .and_then(move |res| {
-            let post = res?;
+        .and_then(move |post| {
             info!("Posted reply {} to thread {}", post.id, post.thread_id);
             Ok(HttpResponse::SeeOther()
                .header("Location", format!("/thread/{}#post-{}", post.thread_id, post.id))

--- a/src/models.rs
+++ b/src/models.rs
@@ -16,6 +16,7 @@
 
 use chrono::prelude::{DateTime, Utc};
 use schema::{threads, posts};
+use diesel::sql_types::{Text, Integer};
 
 #[derive(Identifiable, Queryable, Serialize)]
 pub struct Thread {
@@ -68,4 +69,24 @@ pub struct NewPost {
     pub body: String,
     pub author_name: String,
     pub author_email: String,
+}
+
+/// This struct models the response of a full-text search query. It
+/// does not use a table/schema definition struct like the other
+/// tables, as no table of this type actually exists.
+#[derive(QueryableByName, Debug)]
+pub struct SearchResult {
+    #[sql_type = "Integer"]
+    pub post_id: i32,
+    #[sql_type = "Integer"]
+    pub thread_id: i32,
+    #[sql_type = "Text"]
+    pub author: String,
+    #[sql_type = "Text"]
+    pub title: String,
+
+    /// Headline represents the result of Postgres' ts_headline()
+    /// function, which highlights search terms in the search results.
+    #[sql_type = "Text"]
+    pub headline: String,
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -23,12 +23,12 @@ table! {
 // Note: Manually inserted as print-schema does not add views.
 table! {
     thread_index (thread_id){
-        thread_id -> Integer,
+        thread_id -> Int4,
         title -> Text,
         thread_author -> Text,
         created -> Timestamptz,
         sticky -> Bool,
-        post_id -> Integer,
+        post_id -> Int4,
         post_author -> Text,
         posted -> Timestamptz,
     }


### PR DESCRIPTION
What the title says.

This is implemented using PostgreSQL's support for full-text search by creating a `tsvector` of several fields of each post and thread in a materialized view and indexing it.

Postgres' `plainto_tsquery` function is used to convert user input to search queries to be executed against the database.

`ts_headline` is used to display relevant snippets from search results on the output page.

Known caveats:

* English is hardcoded as the query language for now
* The materialised view needs to be updated after every change of posts, which currently happens at regular intervals - meaning that it is not always guaranteed to be in sync with the posts & threads on a forum