### PR TITLE
chore(gitattributes): Tell Github Linguist to ignore default.nix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+default.nix linguist-generated=true


### PR DESCRIPTION
The `default.nix` in this repository contains generated code and skews
Github's language statistics. While I'm a big fan of Nix, Converse is
certainly not 80% written in Nix ;-)